### PR TITLE
Expose `requestBeat` and `forceBeat` from `NodeLink`

### DIFF
--- a/lib/binding.js
+++ b/lib/binding.js
@@ -10,6 +10,12 @@ class NodeLink {
     enable(isEnable) {
         return this._addonInstance.enable(isEnable);
     }
+    requestBeat(beat) {
+        return this._addonInstance.requestBeat(beat);
+    }
+    forceBeat(beat) {
+        return this._addonInstance.forceBeat(beat);
+    }
     setTempo(newBpm) {
         return this._addonInstance.setTempo(newBpm);
     }

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -13,6 +13,8 @@ interface LinkSessionInfo {
 interface INodeLinkNative {
   getSessionInfoCurrent(): LinkSessionInfo
   enable(isEnable: boolean): void
+  requestBeat(beat: number): void,
+  forceBeat(beat: number): void,
   setTempo(newBpm: number): void
   setIsPlaying(isPlaying: boolean): void
   enableStartStopSync(isEnable: boolean): void
@@ -29,6 +31,14 @@ class NodeLink {
 
   enable(isEnable: boolean) {
     return this._addonInstance.enable(isEnable)
+  }
+
+  requestBeat(beat: number): void {
+    return this._addonInstance.requestBeat(beat)
+  }
+
+  forceBeat(beat: number): void {
+    return this._addonInstance.forceBeat(beat)
   }
 
   setTempo(newBpm: number) {

--- a/src/node_link.cc
+++ b/src/node_link.cc
@@ -4,6 +4,12 @@
 
 #include "node_link.h"
 
+namespace {
+
+double DEFAULT_QUANTUM = 4.0;
+
+}; // anonymous namespace
+
 NodeLink::NodeLink(const Napi::CallbackInfo& info) : ObjectWrap(info), _link(120.0) {
     this->_link.enable(true);
     // this->_link.enableStartStopSync(true);
@@ -11,8 +17,7 @@ NodeLink::NodeLink(const Napi::CallbackInfo& info) : ObjectWrap(info), _link(120
 
 Napi::Value NodeLink::GetSessionInfoCurrent(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto quantum = 4.0;
-    return GetSessionInfoAtTime(env, quantum, GetCurrentTime());
+    return GetSessionInfoAtTime(env, DEFAULT_QUANTUM, GetCurrentTime());
 }
 
 void NodeLink::Enable(const Napi::CallbackInfo& info) {
@@ -48,6 +53,46 @@ void NodeLink::SetTempo(const Napi::CallbackInfo& info) {
 
     auto sessionState = _link.captureAppSessionState();
     sessionState.setTempo(newTempo, GetCurrentTime());
+    _link.commitAppSessionState(sessionState);
+};
+
+void NodeLink::RequestBeat(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+
+    if (info.Length() < 1) {
+        Napi::TypeError::New(env, "Too Few Arguments. 1 double required").ThrowAsJavaScriptException();
+        return;
+    }
+
+    if (!info[0].IsNumber()) {
+        Napi::TypeError::New(env, "Wrong arguments. Number required").ThrowAsJavaScriptException();
+        return;
+    }
+
+    double newBeat = info[0].As<Napi::Number>().DoubleValue();
+
+    auto sessionState = _link.captureAppSessionState();
+    sessionState.requestBeatAtTime(newBeat, GetCurrentTime(), DEFAULT_QUANTUM);
+    _link.commitAppSessionState(sessionState);
+};
+
+void NodeLink::ForceBeat(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+
+    if (info.Length() < 1) {
+        Napi::TypeError::New(env, "Too Few Arguments. 1 double required").ThrowAsJavaScriptException();
+        return;
+    }
+
+    if (!info[0].IsNumber()) {
+        Napi::TypeError::New(env, "Wrong arguments. Number required").ThrowAsJavaScriptException();
+        return;
+    }
+
+    double newBeat = info[0].As<Napi::Number>().DoubleValue();
+
+    auto sessionState = _link.captureAppSessionState();
+    sessionState.forceBeatAtTime(newBeat, GetCurrentTime(), DEFAULT_QUANTUM);
     _link.commitAppSessionState(sessionState);
 };
 

--- a/src/node_link.cc
+++ b/src/node_link.cc
@@ -136,6 +136,8 @@ Napi::Function NodeLink::GetClass(Napi::Env env) {
     return DefineClass(env, "NodeLink", {
         NodeLink::InstanceMethod("getSessionInfoCurrent", &NodeLink::GetSessionInfoCurrent),
         NodeLink::InstanceMethod("enable", &NodeLink::Enable),
+        NodeLink::InstanceMethod("requestBeat", &NodeLink::RequestBeat),
+        NodeLink::InstanceMethod("forceBeat", &NodeLink::ForceBeat),
         NodeLink::InstanceMethod("setTempo", &NodeLink::SetTempo),
         NodeLink::InstanceMethod("setIsPlaying", &NodeLink::SetIsPlaying),
         NodeLink::InstanceMethod("enableStartStopSync", &NodeLink::EnableStartStopSync)

--- a/src/node_link.h
+++ b/src/node_link.h
@@ -22,6 +22,10 @@ public:
 
     void Enable(const Napi::CallbackInfo &);
 
+    void RequestBeat(const Napi::CallbackInfo &);
+
+    void ForceBeat(const Napi::CallbackInfo &);
+
     void SetTempo(const Napi::CallbackInfo &);
 
     void SetIsPlaying(const Napi::CallbackInfo &);


### PR DESCRIPTION
These methods let the client change the current beat (or phase).